### PR TITLE
Fix configure bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,9 +45,9 @@ AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_MAKE_SET
 AC_PROG_YACC
-AS_IF([test x"$YACC" == x"yacc"], [AC_MSG_ERROR([Please install bison or byacc before configuring.])])
+AS_IF([test x"$YACC" = x"yacc"], [AC_MSG_ERROR([Please install bison or byacc before configuring.])])
 AC_PROG_LEX(noyywrap)
-AS_IF([test x"$LEX" == x":"], [AC_MSG_ERROR([Please install flex before configuring.])])
+AS_IF([test x"$LEX" = x":"], [AC_MSG_ERROR([Please install flex before configuring.])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h \


### PR DESCRIPTION
When run with dash as /bin/sh the configure script complains twice about 'unexpected operator', which is due to a use of unportable, bash-specific comparisons.

Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
